### PR TITLE
Open empty workbook if no path

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,10 @@
 Currently this will print out:
 
 ```sh
-Usage: sheetui [OPTIONS] <WORKBOOK>
+Usage: sheetui [OPTIONS] [WORKBOOK]
 
 Arguments:
-  <WORKBOOK>
+  [WORKBOOK]
 
 Options:
   -l, --locale-name <LOCALE_NAME>      [default: en]
@@ -19,6 +19,8 @@ Options:
   -h, --help                           Print help
   -V, --version                        Print version
 ```
+
+If you do not provide a workbook path, sheetui will open an empty workbook.
 
 ## Supported formats
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ mod ui;
 #[command(version, about, long_about = None)]
 pub struct Args {
     #[arg()]
-    workbook: PathBuf,
+    workbook: Option<PathBuf>,
     #[arg(default_value_t=String::from("en"), short, long)]
     locale_name: String,
     #[arg(default_value_t=String::from("America/New_York"), short, long)]
@@ -27,7 +27,11 @@ pub struct Args {
 type ReadFn = Box<dyn FnMut() -> anyhow::Result<event::Event>>;
 
 fn run(terminal: &mut ratatui::DefaultTerminal, args: Args) -> anyhow::Result<ExitCode> {
-    let mut ws = Workspace::load(&args.workbook, &args.locale_name, &args.timezone_name)?;
+    let mut ws = if let Some(workbook_path) = &args.workbook {
+        Workspace::load(workbook_path, &args.locale_name, &args.timezone_name)?
+    } else {
+        Workspace::new_empty(&args.locale_name, &args.timezone_name)?
+    };
     let mut read_func: ReadFn = if let Some(log_path) = args.log_input {
         {
             let log_file = std::fs::File::create(log_path)?;


### PR DESCRIPTION
This might just be my own use cases, but I often want to open up a temporary workbook for quick calcs or build a workbook from scratch. 

This PR opens makes a workbook path optional and opens an empty workbook if no path is provided.

Feel free to reject if this is not in line with your vision for this project.