### PR TITLE
Vim-style append new line above/below current cell

### DIFF
--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -32,6 +32,8 @@ will clear the numeric prefix if you want to cancel it.
 * 'I' will toggle italic on the cell. 'B' will toggle bold.
 * `Ctrl-h` will shorten the width of the column you are on.
 * `Ctrl-l` will lengthen the width of the column you are on.
+* `o` will insert a row below the selected cell, move one cell down, and enter edit mode
+* `O` will insert a row above the selected cell, move one cell up, and enter edit mode
 
 ## Other Keybindings
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -881,6 +881,18 @@ impl<'ws> Workspace<'ws> {
                         self.state.char_queue.push('g');
                     }
                 }
+                KeyCode::Char('o') => {
+                    self.book.insert_rows(self.book.location.row+1, 1)?;
+                    self.move_down()?;
+                    self.handle_movement_change();
+                    self.enter_edit_mode();
+                },
+                KeyCode::Char('O') => {
+                    self.book.insert_rows(self.book.location.row, 1)?;
+                    self.move_up()?;
+                    self.handle_movement_change();
+                    self.enter_edit_mode();
+                },
                 _ => {
                     // noop
                     self.state.char_queue.clear();


### PR DESCRIPTION
Vim-style keybindings in navigation mode for 'o' and 'O' that add a line above or below, switch to that line, and open edit mode.